### PR TITLE
REC-233: Implementa verificación de recetas en ANDES

### DIFF
--- a/src/controllers/andesPrescription.controller.ts
+++ b/src/controllers/andesPrescription.controller.ts
@@ -314,6 +314,40 @@ class AndesPrescriptionController implements BaseController {
         }
     };
 
+    public verificarReceta = async (req: Request, res: Response): Promise<Response> => {
+        const { dni, conceptId } = req.query;
+
+        if (!dni || !conceptId) {
+            return res.status(400).json({ mensaje: 'Se requieren los parámetros dni y conceptId' });
+        }
+
+        try {
+            // Consulta la DB local por DNI del paciente (identificador común entre sistemas)
+            const estadosValidos = ['vigente', 'pendiente'];
+            const estadosDispensaExcluidos = ['dispensada'];
+
+            const recetasLocales = await PrescriptionAndes.find({
+                'paciente.documento': dni,
+                'medicamento.concepto.conceptId': conceptId,
+                'estadoActual.tipo': { $in: estadosValidos },
+                'estadoDispensaActual.tipo': { $nin: estadosDispensaExcluidos }
+            }).lean();
+
+            // Consulta a Andes por documento y conceptId utilizando el endpoint especifico
+            const verificacionAndes = await AndesService.verificarRecetaExistente(dni as string, conceptId as string).catch(() => null);
+            const recetasAndes = verificacionAndes && verificacionAndes.existe && verificacionAndes.receta 
+                ? [verificacionAndes.receta] 
+                : [];
+
+            // Combinar resultados
+            const allRecetas = [...recetasLocales, ...recetasAndes];
+
+            return res.status(200).json(allRecetas);
+        } catch (e) {
+            return res.status(500).json({ mensaje: 'Error al verificar receta', error: e });
+        }
+    };
+
 }
 
 export default new AndesPrescriptionController();

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -57,6 +57,7 @@ class PrivateRoutes {
 
         // Andes prescriptions
         this.router.get('/andes-prescriptions/from-andes/', hasPermissionIn('readAny', 'prescription'), andesPrescriptionController.getFromAndes);
+        this.router.get('/andes-prescriptions/verificar', hasPermissionIn('readAny', 'prescription'), andesPrescriptionController.verificarReceta);
         this.router.get('/andes-prescriptions/:id', hasPermissionIn('readAny', 'prescription'), andesPrescriptionController.show);
         this.router.patch('/andes-prescriptions/dispense', hasPermissionIn('updateAny', 'prescription'), andesPrescriptionController.dispense);
         this.router.patch('/andes-prescriptions/cancel-dispense', hasPermissionIn('updateAny', 'prescription'), andesPrescriptionController.cancelDispense);

--- a/src/services/andesService.ts
+++ b/src/services/andesService.ts
@@ -41,6 +41,8 @@ class AndesService {
 
             const fullUrl = queryParams.toString() ? `${url}?${queryParams.toString()}` : url;
 
+            console.log('fullUrl', fullUrl);
+
             const response: AxiosResponse<IPrescriptionAndes[]> = await axios.get(fullUrl, {
                 headers: {
                     Authorization: this.token,
@@ -143,6 +145,32 @@ class AndesService {
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error('Error al obtener prescripciones por profesional desde ANDES:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Verifica si existe una receta vigente para un paciente y medicamento (por conceptId SNOMED) en ANDES
+     */
+    public async verificarRecetaExistente(dni: string, conceptId: string): Promise<any> {
+        try {
+            const url = `${this.baseURL}/modules/recetas/verificar`;
+            console.log('fullUrl', url);
+
+            const response: AxiosResponse<any> = await axios.get(url, {
+                params: { documento: dni, conceptId },
+                headers: {
+                    Authorization: this.token,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            console.log('response', response.data);
+
+            return response.data;
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Error al verificar receta existente en ANDES:', error);
             throw error;
         }
     }


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
https://proyectos.andes.gob.ar/browse/REC-233

> [!WARNING]
> Requiere PR de Andes https://github.com/andes/api/pull/2233 

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se implementó (o ajustó) el endpoint `GET /recetas/verificar` en el AndesPrescriptionController.
2. Se migró la lógica de búsqueda de recetas. En lugar de usar un ID interno de base de datos (pacienteId), ahora se utiliza el DNI (documento) del paciente. Esto asegura la sincronización correcta con los registros de Andes.
3. La consulta en la base de datos busca recetas que cumplan tres condiciones:
      - Pertenecer al DNI del paciente.
      - Coincidir con el conceptId del medicamento seleccionado.
      - Tener un estado "vigente" o "pendiente" y que no hayan sido dispensadas totalmente.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->